### PR TITLE
Add "FACTORY" as a service name for Buds2 support

### DIFF
--- a/Headtracking.py
+++ b/Headtracking.py
@@ -92,7 +92,7 @@ def main():
 
     port = host = None
     for match in service_matches:
-        if match["name"] == "GEARMANAGER" or match["name"] == b"GEARMANAGER" or match["name"] == b"FACTORY":
+        if match["name"] == "GEARMANAGER" or match["name"] == b"GEARMANAGER" or match["name"] == b"FACTORY" or match["name"] == "FACTORY":
             port = match["port"]
             host = match["host"]
             break


### PR DESCRIPTION
Added "FACTORY" as a service name alongside b"FACTORY" since in my case it was a string and not a bytes literal.